### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node discord_bot.js"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Before the first run you will need to create an `auth.json` file. A bot token or
 To start the bot just run
 `node discord_bot.js`.
 
+# Running on Repl.it
+You will also need to create an `auth.json` file with your credentials with this process, follow the steps above.
+[![Run on Repl.it](https://repl.it/badge/github/chalda/DiscordBot)](https://repl.it/github/chalda/DiscordBot)
+
 # Updates
 If you update the bot, please run `npm update` before starting it again. If you have
 issues with this, you can try deleting your node_modules folder and then running


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@pieromqwerty/DiscordBot).