### PR TITLE
Add support for queuing entire spotify playlists

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -15,7 +15,9 @@ if(!AuthDetails.hasOwnProperty('bot_token')) {
 		imgflip_username: process.env.imgflip_username,
 		imgflip_password: process.env.imgflip_password,
 		wolfram_api_key: process.env.wolfram_api_key,
-		twitch_client_id: process.env.twitch_client_id
+		twitch_client_id: process.env.twitch_client_id,
+		spotify_client_id: process.env.spotify_client_id,
+		spotify_client_secret: process.env.spotify_client_secret
 	}
 }
 

--- a/auth.json.example
+++ b/auth.json.example
@@ -10,5 +10,7 @@
   "wolfram_api_key": "go here and click sign up http://products.wolframalpha.com/api/",
   "twitch_client_id": "create a twitch app here https://dev.twitch.tv/dashboard/apps/create (requires a twitch account)",
   "twitch_client_secret": "get this from the twitch dev dashboard once you've created your twitch app",
-  "worldtradingdata_api_key": "create one at https://www.worldtradingdata.com/register"
+  "worldtradingdata_api_key": "create one at https://www.worldtradingdata.com/register",
+  "spotify_client_id": "create an app at https://developer.spotify.com/my-applications/",
+  "spotify_client_secret": "create an app at https://developer.spotify.com/my-applications/"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,7 +314,7 @@
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -333,7 +333,7 @@
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -454,7 +454,7 @@
     "bufferutil": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
-      "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "integrity": "sha1-Ohd+jlgZoSQ/4WtjoZmVGnrY1Kc=",
       "requires": {
         "node-gyp-build": "~3.7.0"
       }
@@ -473,6 +473,15 @@
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "caller": {
@@ -613,7 +622,7 @@
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -640,6 +649,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -760,7 +774,7 @@
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -854,12 +868,12 @@
     "domelementtype": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8="
     },
     "domhandler": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
       "requires": {
         "domelementtype": "1"
       }
@@ -898,7 +912,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+      "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY="
     },
     "env-paths": {
       "version": "2.2.0",
@@ -926,7 +940,7 @@
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1122,6 +1136,11 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
     "feedparser": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/feedparser/-/feedparser-1.1.6.tgz",
@@ -1175,7 +1194,7 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
       "optional": true
     },
     "fill-range": {
@@ -1270,6 +1289,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -1309,7 +1333,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "gauge": {
       "version": "2.7.4",
@@ -1324,6 +1348,16 @@
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
         "wide-align": "^1.1.0"
+      }
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
       }
     },
     "get-stream": {
@@ -1350,7 +1384,7 @@
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1401,7 +1435,7 @@
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1409,7 +1443,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg="
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -1468,7 +1502,7 @@
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8="
     },
     "hh-mm-ss": {
       "version": "1.2.0",
@@ -1515,7 +1549,7 @@
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
       "requires": {
         "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
@@ -1642,7 +1676,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
     },
     "ini": {
       "version": "1.3.5",
@@ -1675,7 +1709,7 @@
     "is-arguments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM="
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -1716,7 +1750,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -1808,7 +1842,7 @@
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -1935,6 +1969,11 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
     "micromatch": {
       "version": "3.1.10",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -1981,7 +2020,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2043,7 +2082,7 @@
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0="
     },
     "nan": {
       "version": "2.14.1",
@@ -2108,7 +2147,7 @@
     "node-gyp-build": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.7.0.tgz",
-      "integrity": "sha512-L/Eg02Epx6Si2NXmedx+Okg+4UHqmaf3TNcxd50SF9NQGcJaON3AtU++kax69XV7YWz4tUspqZSAsVofhFKG2w=="
+      "integrity": "sha1-2qd6T1R7mu0+Kqx3nq8VGv1g7I0="
     },
     "node-wolfram": {
       "version": "0.0.1",
@@ -5453,7 +5492,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -5719,7 +5758,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
     },
     "qs": {
       "version": "6.5.2",
@@ -5900,7 +5939,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "sax": {
       "version": "1.2.4",
@@ -5974,6 +6013,23 @@
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
           "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ="
+        }
+      }
+    },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "dependencies": {
+        "object-inspect": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.2.tgz",
+          "integrity": "sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA=="
         }
       }
     },
@@ -6144,10 +6200,18 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "spotify-web-api-node": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/spotify-web-api-node/-/spotify-web-api-node-5.0.2.tgz",
+      "integrity": "sha512-r82dRWU9PMimHvHEzL0DwEJrzFk+SMCVfq249SLt3I7EFez7R+jeoKQd+M1//QcnjqlXPs2am4DFsGk8/GCsrA==",
+      "requires": {
+        "superagent": "^6.1.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+      "integrity": "sha1-2hdlJiv4wPVxdJ8q1sJjACB65nM="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -6275,6 +6339,67 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "superagent": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
+      "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.2",
+        "methods": "^1.1.2",
+        "mime": "^2.4.6",
+        "qs": "^6.9.4",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "tape": {
       "version": "2.3.3",
@@ -6407,7 +6532,7 @@
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
-      "integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
+      "integrity": "sha1-/CrSVbi9MJ4jnLxYFv0jqbfqQCM=",
       "requires": {
         "sprintf-js": "^1.0.3",
         "util-deprecate": "^1.0.2"
@@ -6473,7 +6598,7 @@
     "urban": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/urban/-/urban-0.3.2.tgz",
-      "integrity": "sha512-B0/cCQNb1XCwHA0YGw1u9IavHMbHe8ruxkUNUlYHobMCAWdk0/gFfOCQQ11CQDmlFu4SUZRoVxrUF3kbE0gdog==",
+      "integrity": "sha1-tXHjn7f0x6BfKKu4BB5kXKw38t4=",
       "requires": {
         "commander": ">=0.3.0"
       }
@@ -6646,7 +6771,7 @@
     "xml2js": {
       "version": "0.4.23",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "integrity": "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -6655,7 +6780,7 @@
     "xmlbuilder": {
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+      "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM="
     },
     "y18n": {
       "version": "3.2.1",
@@ -6708,7 +6833,7 @@
     "youtube-node": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/youtube-node/-/youtube-node-1.3.3.tgz",
-      "integrity": "sha512-LLlTZtu2itJ0KdeRWf5CUhPBo0di4LEloqWaZlPezbSPyUWNRkeNiKstv4+hSgh6CtslKAUhponVD36uMQRm/g==",
+      "integrity": "sha1-/E+r+YdCUmllachej5+C9Bqab5I=",
       "requires": {
         "colors": "^1.3.3",
         "prompt": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "request": "2.88.2",
     "request-promise": "4.2.1",
     "split-camelcase-to-words": "^1.0.1",
+    "spotify-web-api-node": "^5.0.2",
     "string-sanitizer": "^1.1.1",
     "tumblr.js": "0.0.x",
     "urban": "^0.3.1",

--- a/plugins/MusicPlayer/player.js
+++ b/plugins/MusicPlayer/player.js
@@ -19,7 +19,8 @@ exports.commands = [
     "dequeue",
     "pause",
     "resume",
-    "playlist"
+    "playlist",
+    "shuffle"
 ]
 
 function getResultTitle(result){
@@ -68,6 +69,13 @@ function getUserVoiceChannel(msg) {
  */
 function wrap(text) {
 	return '```\n' + text.replace(/`/g, '`' + String.fromCharCode(8203)) + '\n```';
+}
+
+function shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
 }
 
 class Player {
@@ -273,19 +281,40 @@ exports.skip = {
 }
 
 exports.queue = {
-    description: "prints the current music queue for this server",
-	process: function(client, msg, suffix) {
+    usage: "[-s]",
+    description: "prints the current music queue for this server. -s to print in concise form",
+	process: async function(client, msg, suffix) {
         let player = getPlayer(msg.guild.id);
         const length = player.queue.length;
         var count = 0;
-        let msg_maker = (msg)=>{
-            if(count == length) return;
-            const song = player.queue[count];
-            const title = count == 0 ? 'Now Playing:' : `${count}:`;
-            count += 1;
-            msg.channel.send('',generateResultEmbed(title,song.info,song.queuer)).then(msg_maker);
+        if(suffix.includes("-s")){
+            let list = player.queue.map((song)=>{
+                let entry = (count == 0 ? 'Now Playing: ' : `${count}: `) + getResultTitle(song.info) + '\n';
+                count++;
+                return entry;
+            });
+            let response = "";
+            while(list.length > 0) {
+                let entry = list.shift();
+                let newmsg = response + entry;
+                if(newmsg.length > (1024 - 8)){
+                    await msg.channel.send(response);
+                    response = entry;
+                } else {
+                    response = newmsg;
+                }
+            }
+            msg.channel.send(response);
+        } else {
+            let msg_maker = (msg)=>{
+                if(count == length) return;
+                const song = player.queue[count];
+                const title = count == 0 ? 'Now Playing:' : `${count}:`;
+                count += 1;
+                msg.channel.send('',generateResultEmbed(title,song.info,song.queuer)).then(msg_maker);
+            }
+            msg_maker(msg);
         }
-        msg_maker(msg);
     }
 }
 
@@ -355,8 +384,10 @@ exports.resume = {
 }
 
 exports.playlist = {
+    usage: "`<https://open.spotify.com/playlist/...|spotify:playlist:...>`",
     description: "plays spotify playlists",
-    process: async function(client, msg, suffix) {
+    process: async function(client, msg, suffix, isEdit) {
+        if(isEdit) return;
         // Make sure the suffix exists.
         if (!suffix) return msg.channel.send( wrap('No playlist specified!'));
 
@@ -394,8 +425,10 @@ exports.playlist = {
                 spotifyApi.setAccessToken(result.body['access_token']);
                 console.log("requesting playlist details for " + playlist_id);
                 let playlist = await spotifyApi.getPlaylist(playlist_id);
+                var embed = null;
+
                 if(show_playlist){
-                    msg.channel.send("",{
+                    embed = {
                         embed: {
                             color: 0x1db954,
                             author: {
@@ -407,14 +440,19 @@ exports.playlist = {
                             },
                             title: playlist.body.name
                         }
-                    });
+                    };
                 }
+                let response = await msg.channel.send("Processing playlist: 0 of " + playlist.body.tracks.items.length,embed);
+                
                 // Now queue up the songs for playback
                 let player = getPlayer(msg.guild.id);
                 console.log("Starting search of youtube for tracks in this playlist...");
-                for(item of playlist.body.tracks.items) {
-                    let song_search = 'ytsearch1:' + item.track.name + ' ' + item.track.artists[0].name;
-                    try {
+                let songs = []
+                //Kick off the searches in parallel.
+                let searches = new Promise(async (resolve) => {
+                    for(item of playlist.body.tracks.items) {
+                        let song_search = 'ytsearch1:' + item.track.name + ' ' + item.track.artists[0].name;
+                        console.log("Searching for " + item.track.name + ' ' + item.track.artists[0].name);
                         let promise = new Promise((resolve, reject) => {
                             YoutubeDL.getInfo(song_search, ['-i','--max-downloads', '1', '--no-playlist', '--no-check-certificate'], (err,info) =>{
                                 if(err){
@@ -424,24 +462,52 @@ exports.playlist = {
                                 }
                             });
                         });
-
-                        let info = await promise;
-
+                        songs.push(promise);
+                        //Throttle our queries somewhat so we don't piss off youtube.
+                        await new Promise(r => setTimeout(r, 1000));
+                    }
+                    console.log("Done searching for " + playlist_id);
+                    resolve();
+                });
+                let loaded = 0;
+                let edited = true;
+                for(song of songs) {
+                    try {
+                        let info = await song;
                         player.enqueue(client,msg,null,info);
                     } catch (e) {
-                        console.log("failed trying to search for a song with " + song_search);
-                        conseole.error(e);
+                        console.log("failed trying to search for a song!");
+                        console.error(e);
+                    }
+                    loaded++;
+                    if(edited){
+                        edited = false;
+                        response.edit("Processing playlist: " + loaded + " of " + playlist.body.tracks.items.length,embed).then(()=>{edited = true;});
                     }
                 }
-                console.log("All tracks in playlist" + playlist_id + " queued");
+                console.log("All tracks in playlist " + playlist_id + " queued");
+                response.edit("playlist queued",embed);
             } catch(e) {
                 if(!AuthDetails.spotify_client_id || !AuthDetails.spotify_client_secret){
                     console.log("Missing spotify api credentials. Did you add them to auth.json?");
-                    console.error(e);
                 }
+                console.error(e);
                 return msg.channel.send("Couldn't read the playlist :(");
             }
         }
         
+    }
+}
+
+exports.shuffle = {
+    description: "Shuffles the play queue",
+    process: function (client, msg, suffix) {
+        let player = getPlayer(msg.guild.id);
+        if(player) {
+            shuffleArray(player.queue);
+            msg.channel.send("Shuffled the play queue!");
+        } else {
+            msg.channel.send("Couldn't find a player. Are you playing music?");
+        }
     }
 }

--- a/plugins/MusicPlayer/player.js
+++ b/plugins/MusicPlayer/player.js
@@ -1,6 +1,8 @@
 const YoutubeDL = require('youtube-dl');
 const Discord = require('discord.js');
 const MemoryStream = require('memorystream');
+const SpotifyWebApi = require('spotify-web-api-node');
+const AuthDetails = require("../../auth.js").getAuthDetails();
 
 let options = false;
 const MUSIC_CHANNEL_NAME = (options && options.musicChannelName) || 'music';
@@ -16,7 +18,8 @@ exports.commands = [
     "queue",
     "dequeue",
     "pause",
-    "resume"
+    "resume",
+    "playlist"
 ]
 
 function getResultTitle(result){
@@ -136,10 +139,18 @@ class Player {
             console.log("YoutubeDL Stream end");
         })
         setTimeout(()=>{
-            if(this.queue[0].response.channel){
-                const embed = generateResultEmbed('Now Playing',video_info,this.queue[0].queuer);
-                this.queue[0].response.channel.send('',embed);
-                this.queue[0].response.delete();
+            if(this.queue[0].response){
+                if(this.queue[0].response.channel){
+                    const embed = generateResultEmbed('Now Playing',video_info,this.queue[0].queuer);
+                    this.queue[0].response.channel.send('',embed);
+                    this.queue[0].response.delete();
+                }
+            } else {
+                let msg_channel = this.voiceChannel.guild.channels.cache.find((v)=>v.type == "text" && v.name === MUSIC_CHANNEL_NAME);
+                if(msg_channel){
+                    const embed = generateResultEmbed('Now Playing',video_info,this.queue[0].queuer);
+                    msg_channel.send('',embed);
+                }
             }
         const dispatcher = connection.play(buffer,{bitrate:'auto',volume:true});
         this.stream = stream;
@@ -340,5 +351,97 @@ exports.resume = {
         // Resume.
         msg.channel.send( wrap('Playback resumed.'));
         player.resume();
+    }
+}
+
+exports.playlist = {
+    description: "plays spotify playlists",
+    process: async function(client, msg, suffix) {
+        // Make sure the suffix exists.
+        if (!suffix) return msg.channel.send( wrap('No playlist specified!'));
+
+        // Make sure the user is in voice.
+        var arr = msg.guild.channels.cache.filter((v)=>v.type == "voice").filter((v)=>v.members.has(msg.author.id));
+        let responseChannel = msg.guild.channels.cache.find((v)=>v.type == "text" && v.name === MUSIC_CHANNEL_NAME) || msg.channel;
+        if (arr.length == 0) return msg.channel.send( wrap('You\'re not in a voice channel.'));
+
+        var show_playlist = true;
+
+        var playlist_id = null;
+        let uri_re = /spotify:playlist:(\w+)/i;
+        let uri = uri_re.exec(suffix);
+        if(uri) {
+            playlist_id = uri[1];
+        } else {
+            let link_re = /https:\/\/open.spotify.com\/playlist\/(\w+).*/i
+            let link = link_re.exec(suffix);
+            if(link) {
+                playlist_id = link[1];
+            }
+            //Don't show our playlist embed with an open spotify link since discord makes a nice embed.
+            show_playlist = false;
+        }
+        if(!playlist_id){
+            return msg.channel.send("This doesn't look like a spotify playlist to me...");
+        } else {
+            try {
+                var spotifyApi = new SpotifyWebApi({
+                    clientId: AuthDetails.spotify_client_id,
+                    clientSecret: AuthDetails.spotify_client_secret
+                });
+                console.log("requesting spotify access token");
+                let result = await spotifyApi.clientCredentialsGrant();
+                spotifyApi.setAccessToken(result.body['access_token']);
+                console.log("requesting playlist details for " + playlist_id);
+                let playlist = await spotifyApi.getPlaylist(playlist_id);
+                if(show_playlist){
+                    msg.channel.send("",{
+                        embed: {
+                            color: 0x1db954,
+                            author: {
+                                name: playlist.body.owner.display_name,
+                            },
+                            url: playlist.body.external_urls.spotify,
+                            image: {
+                                url: playlist.body.images[0].url,
+                            },
+                            title: playlist.body.name
+                        }
+                    });
+                }
+                // Now queue up the songs for playback
+                let player = getPlayer(msg.guild.id);
+                console.log("Starting search of youtube for tracks in this playlist...");
+                for(item of playlist.body.tracks.items) {
+                    let song_search = 'ytsearch1:' + item.track.name + ' ' + item.track.artists[0].name;
+                    try {
+                        let promise = new Promise((resolve, reject) => {
+                            YoutubeDL.getInfo(song_search, ['-i','--max-downloads', '1', '--no-playlist', '--no-check-certificate'], (err,info) =>{
+                                if(err){
+                                    reject(err);
+                                } else {
+                                    resolve(info);
+                                }
+                            });
+                        });
+
+                        let info = await promise;
+
+                        player.enqueue(client,msg,null,info);
+                    } catch (e) {
+                        console.log("failed trying to search for a song with " + song_search);
+                        conseole.error(e);
+                    }
+                }
+                console.log("All tracks in playlist" + playlist_id + " queued");
+            } catch(e) {
+                if(!AuthDetails.spotify_client_id || !AuthDetails.spotify_client_secret){
+                    console.log("Missing spotify api credentials. Did you add them to auth.json?");
+                    console.error(e);
+                }
+                return msg.channel.send("Couldn't read the playlist :(");
+            }
+        }
+        
     }
 }


### PR DESCRIPTION
This adds support for queuing entire spotify playlists for playback with `!playlist`. Each song will be searched for with youtube-dl and then queued for playback.

Requires spotify app credentials to use their API.

Should be extensible to other types of playlists by adding more regexps that map to other services.