### PR TITLE
Add command to set presence

### DIFF
--- a/discord_bot.js
+++ b/discord_bot.js
@@ -33,7 +33,7 @@ if (!AuthDetails.hasOwnProperty("bot_token") || AuthDetails.bot_token === "") {
 }
 
 // Load custom permissions
-let dangerousCommands = ["exec", "eval", "pullanddeploy", "setUsername", "cmdauth"]; // set array of dangerous commands
+let dangerousCommands = ["exec", "eval", "pullanddeploy", "setUsername", "cmdauth", "presence"]; // set array of dangerous commands
 let Permissions = {};
 try {
   Permissions = require("./permissions.json");

--- a/discord_bot.js
+++ b/discord_bot.js
@@ -170,6 +170,25 @@ commands = {
       bot.user.setStatus("online").then(console.log).catch(console.error);
     },
   },
+  presence: {
+    usage: "<presence text>",
+    description: "Sets bot's presence.",
+    process: function (bot, msg, suffix) {
+      if (!suffix){
+        bot.user.setPresence({
+          activity: {
+            name:
+              Config.commandPrefix +
+              "help | " +
+              bot.guilds.cache.array().length +
+              " Servers",
+          },
+        });
+      } else {
+        bot.user.setPresence({activity: {name: suffix}}).then(console.log).catch(console.error);
+      }
+    },
+  },
   say: {
     usage: "<message>",
     description: "Bot sends message",

--- a/permissions.json.example
+++ b/permissions.json.example
@@ -10,7 +10,8 @@
     "eval": false,
     "pullanddeploy": false,
     "setUsername": false,
-    "cmdauth": false
+    "cmdauth": false,
+    "presence": false
   },
   "users": {
     "12300000000000004": {


### PR DESCRIPTION
Ability to set presence of the bot. If the user does not provide a string after the command, set it to the default presence text.
Closes #168 
