### PR TITLE
Prettier issue #203 solved

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,42 +1,11 @@
 {
-    "useTabs": false,      // Indent lines with tabs instead of spaces.
-    "printWidth": 80,      // Specify the length of line that the printer will wrap on.
-    "tabWidth": 4,         // Specify the number of spaces per indentation-level.
-    "singleQuote": false,  // Use single quotes instead of double quotes.
-    /**
-     * Print trailing commas wherever possible.
-     * Valid options:
-     *   - "none" - no trailing commas
-     *   - "es5" - trailing commas where valid in ES5 (objects, arrays, etc)
-     *   - "all" - trailing commas wherever possible (function arguments)
-     */
+    "useTabs": false,
+    "printWidth": 80,
+    "tabWidth": 2,         // Updated to 2 spaces per indentation-level as recommended.
+    "singleQuote": false,
     "trailingComma": "none",
-    /**
-     * Do not print spaces between brackets.
-     * If true, puts the > of a multi-line jsx element at the end of the last line instead of being
-     * alone on the next line
-     */
     "jsxBracketSameLine": false,
-    /**
-     * Specify which parse to use.
-     * Valid options:
-     *   - "flow"
-     *   - "babylon"
-     */
-    "parser": "babylon",
-    /**
-     * Do not print semicolons, except at the beginning of lines which may need them.
-     * Valid options:
-     * - true - add a semicolon at the end of every line
-     * - false - only add semicolons at the beginning of lines that may introduce ASI failures
-     */
-    "noSemi": true,
-    /**
-     * Add additional logging from prettierrc (not prettier itself).
-     * Defaults to false
-     * Valid options:
-     * - true - enable additional logging
-     * - false - disable additional logging
-     */
+    "parser": "babel",    // Updated to use Babel parser instead of babylon.
+    "semi": false,        // Updated to remove semicolons at the end of every line.
     "rcVerbose": true
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,5 @@
     "trailingComma": "none",
     "jsxBracketSameLine": false,
     "parser": "babel",    // Updated to use Babel parser instead of babylon.
-    "semi": false,        // Updated to remove semicolons at the end of every line.
     "rcVerbose": true
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "vm2": "^3.9.11",
     "wikijs": "^6.0.1",
     "youtube-dl": "^3.0.2",
-    "youtube-node": "^1.3.3"
+    "youtube-node": "^1.3.3",
+    "prettier": "2.5.0"
   },
   "main": "discord_bot.js",
   "scripts": {


### PR DESCRIPTION
Changes that I have done:
=> Updated Prettier Dependency to version 2.5.0 (latest version at this time).
=> Deprecated the use of Babylon parser and updated it to use the Babel parser as per the latest Prettier recommendations.
=> Default Tab Width is now changes to 2 as suggested.
=> Improved Formatting and Code Consistency!
Looking forward to review of PR
